### PR TITLE
Add missing pip install command to GitHub workflow

### DIFF
--- a/.github/workflows/sync-malicious-packages.yaml
+++ b/.github/workflows/sync-malicious-packages.yaml
@@ -35,6 +35,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r scripts/sync-malicious-packages/requirements.txt
+          pip install -r scripts/generate_manifest/requirements.txt
 
       - name: Synchronize malicious packages
         run: |
@@ -58,3 +59,4 @@ jobs:
           reviewers: |
             christophetd
             sobregosodd
+            ikretz


### PR DESCRIPTION
This PR fixes a bug introduced in c4190c1fafd507721e2b6b5103d0157336ff3e10 wherein the `pip install -r requirements.txt` command for the `generate_manifest` script was missing from the `sync-malicious-packages.yaml` file.

It also adds @ikretz to the list of reviewers for the repository.