### PR TITLE
Ignore npm security versions in sync

### DIFF
--- a/scripts/generate_manifest/generate_manifest.py
+++ b/scripts/generate_manifest/generate_manifest.py
@@ -5,7 +5,7 @@ import json
 import os
 import sys
 
-from packaging.version import parse as version_parse
+from packaging.version import InvalidVersion, parse as version_parse
 
 
 def generate_manifest(directory: str) -> dict[str, list[str]]:
@@ -26,7 +26,10 @@ def generate_manifest(directory: str) -> dict[str, list[str]]:
         for version_dir in version_dirs:
             package_version = restore_original_version(version_dir.name)
             manifest[package_name].append(package_version)
-            manifest[package_name].sort(key=version_parse)
+            try:
+                manifest[package_name].sort(key=version_parse)
+            except InvalidVersion:
+                manifest[package_name].sort()
 
     return {package: manifest[package] for package in sorted(manifest)}
 

--- a/scripts/sync-malicious-packages/sync-malicious-packages.py
+++ b/scripts/sync-malicious-packages/sync-malicious-packages.py
@@ -5,9 +5,10 @@ from pathlib import Path
 import tempfile
 import time
 import subprocess
-import shutil
 
 import boto3
+
+NPM_SECURITY_VERSION = "0.0.1-security"
 
 
 def parse_arguments():
@@ -54,8 +55,10 @@ def query_and_download_items(ecosystem, cutoff_date, dest, dynamodb_table, s3_bu
     scan_datetime = datetime.strptime(item['scan_datetime'], '%Y-%m-%d %H:%M:%S.%f')
     formatted_date = scan_datetime.strftime('%Y-%m-%d')
 
-    package_name = item["package_name"].replace("npm|", "")
+    package_name = item["package_name"].removeprefix("npm|")
     package_version = item["package_version"]
+    if package_name != item["package_name"] and package_version == NPM_SECURITY_VERSION:
+      continue
 
     # Sanitize the package name and version for use in a file or directory name
     # `@` is used in place of `/` for the directory versions because it is:


### PR DESCRIPTION
This PR updates the Python script for syncing the malicious packages so that it ignores npm security placeholder versions, which all have version `0.0.1-security`.

It also adds a fallback option for sorting the entries in the manifest lexicographically in the case that an entry is not parseable as a version number.