### PR TITLE
[SINT-3772] using dd-octo-sts for PR related actions in workflows

### DIFF
--- a/.github/chainguard/self.open_pr.sts.yaml
+++ b/.github/chainguard/self.open_pr.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/malicious-software-packages-dataset:ref:refs/heads/main
+
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/malicious-software-packages-dataset/.github/workflows/sync-malicious-packages.yaml@refs/heads/main
+
+permissions:
+  pull_requests: write

--- a/.github/workflows/sync-malicious-packages.yaml
+++ b/.github/workflows/sync-malicious-packages.yaml
@@ -5,7 +5,7 @@ on:
   schedule:
   - cron: '0 8 * * 1-5' # every weekday at 8 UTC
 
-  
+
 permissions:
   contents: write
   pull-requests: write
@@ -18,11 +18,24 @@ jobs:
     environment: Main
 
     steps:
+      # <TESTING> Only for debugging, remove after testing
+      - name: Debug OIDC Claims
+        uses: github/actions-oidc-debugger@main
+        with:
+          audience: "octo-debugger"
+      # </TESTING>
+
+      - uses: DataDog/dd-octo-sts-action@08f2144903ced3254a3dafec2592563409ba2aa0 # v1.0.1
+        id: octo-sts
+        with:
+          scope: DataDog/malicious-software-packages-dataset  # target repository
+          policy: self.open_pr # trust policy in target repo
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12' 
+          python-version: '3.12'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -56,6 +69,7 @@ jobs:
           title: "[Bot] Auto-synchronize malicious packages"
           labels: sync
           branch-suffix: timestamp
+          token: ${{ steps.octo-sts.outputs.token }}
           reviewers: |
             christophetd
             sobregosodd


### PR DESCRIPTION
# Goal

This is part of an initiative lead by SDLC security to [harden Github security settings](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/3913581900/GitHub+Workflow+Token+Permissions+GITHUB_TOKEN). To do so, we need to move away from GITHUB_TOKEN having the permission to approve and merge PRs, as implemented in `sync-malicious-packages.yaml`.

Instead, [dd-octo-sts](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/4705912130/DD+Octo+STS) is an alternative to provide ephemeral scoped tokens delivering the same features with improved security.

This PR implements the migration to dd-octo-sts.

# Testing
## Using CLI to test with dummy tokens
This test passes:

```
DDOCTOSTS_ID_TOKEN=$(cat claims.json) dd-octo-sts check --scope DataDog/malicious-software-packages-dataset --policy self.open_pr
```

With the following locally fabricated claim.
[claims.json](https://github.com/user-attachments/files/21301135/claims.json)
