### PR TITLE
Update policy write permissions

### DIFF
--- a/.github/chainguard/self.open_pr.sts.yaml
+++ b/.github/chainguard/self.open_pr.sts.yaml
@@ -9,4 +9,5 @@ claim_pattern:
   job_workflow_ref: DataDog/malicious-software-packages-dataset/.github/workflows/sync-malicious-packages.yaml@refs/heads/main
 
 permissions:
+  contents: write
   pull_requests: write


### PR DESCRIPTION
This PR adds the `contents: write` permission to the new `dd-octo-sts` policy to allow the workflow to open PRs.