### PR TITLE
[SINT-3772] dd-octo-sts on-boarding cleanup

### DIFF
--- a/.github/workflows/sync-malicious-packages.yaml
+++ b/.github/workflows/sync-malicious-packages.yaml
@@ -18,12 +18,6 @@ jobs:
     environment: Main
 
     steps:
-      # <TESTING> Only for debugging, remove after testing
-      - name: Debug OIDC Claims
-        uses: github/actions-oidc-debugger@main
-        with:
-          audience: "octo-debugger"
-      # </TESTING>
 
       - uses: DataDog/dd-octo-sts-action@08f2144903ced3254a3dafec2592563409ba2aa0 # v1.0.1
         id: octo-sts


### PR DESCRIPTION
# Goal
Follow-up of https://github.com/DataDog/malicious-software-packages-dataset/pull/299, https://github.com/DataDog/malicious-software-packages-dataset/pull/301, https://github.com/DataDog/malicious-software-packages-dataset/pull/302
Clean-up of debug steps used to on-board the service to dd-octo-sts.