### PR TITLE
fix sync-malicious-packages.py Undefined name `command`

### DIFF
--- a/scripts/sync-malicious-packages/sync-malicious-packages.py
+++ b/scripts/sync-malicious-packages/sync-malicious-packages.py
@@ -83,7 +83,8 @@ def query_and_download_items(ecosystem, cutoff_date, dest, scan_table, triage_ta
       try:
         # Download the folder from S3
         s3_url = f"s3://{s3_bucket}/{ecosystem}/{scan_datetime}/{package_name}/{package_version}/"
-        subprocess.run(['aws', 's3', 'sync', s3_url, tempdir], check=True, capture_output=True)
+        command = ['aws', 's3', 'sync', s3_url, tempdir]
+        subprocess.run(command, check=True, capture_output=True)
       except subprocess.CalledProcessError as e:
         print("Unable to download: " + str(e))
         print("Command: " + " ".join(command))


### PR DESCRIPTION
I accidentally noticed that in the `except` block `print("Command: " + " ".join(command))` will fail because the `command` variable doesn't exist.

The other uses of `join(command)` are fine, the problem is only in one place.

(When using Python =>3.11, then consider using `e.add_note(f'{command=}')` instead of `print`)