### PR TITLE
Add Bitwarden compromised lib sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="./image.png" height="400" />
 </p>
 
-This repository is an **open-source dataset of <span id="num-samples">25581</span> malicious software packages** (and counting) identified by Datadog, as part of our security research efforts in software supply-chain security. Most of the malicious packages have been identified by [GuardDog](https://github.com/DataDog/guarddog).
+This repository is an **open-source dataset of <span id="num-samples">25582</span> malicious software packages** (and counting) identified by Datadog, as part of our security research efforts in software supply-chain security. Most of the malicious packages have been identified by [GuardDog](https://github.com/DataDog/guarddog).
 
 Current ecosystems:
 - npm

--- a/samples/npm/manifest.json
+++ b/samples/npm/manifest.json
@@ -387,6 +387,9 @@
     "@bingads-webui-theme-2018/theme-fluent": null,
     "@biovia/amd-loader": null,
     "@birdmania1/namecheap-mcp": null,
+    "@bitwarden/cli": [
+        "2026.4.0"
+    ],
     "@blockdaemon-internal/design-system": null,
     "@blocks-shared/desktop-title": null,
     "@bmw-fedev/auth": null,


### PR DESCRIPTION
This PR adds a sample for the recent `@bitwarden/cli` compromise [reported](https://socket.dev/blog/bitwarden-cli-compromised) by Socket.