### PR TITLE
Fix Octo config file

### DIFF
--- a/.github/chainguard/self.open_pr.sts.yaml
+++ b/.github/chainguard/self.open_pr.sts.yaml
@@ -7,8 +7,7 @@ claim_pattern:
   ref: refs/heads/main
   ref_protected: "true"
   job_workflow_ref:
-    DataDog/malicious-software-packages-dataset/.github/workflows/sync-malicious-packages.yaml@refs/heads/main
-    DataDog/malicious-software-packages-dataset/.github/workflows/sync-manifest.yaml@refs/heads/main
+    DataDog/malicious-software-packages-dataset/\.github/workflows/sync-(malicious-packages|manifest)\.yaml@refs/heads/main
 
 permissions:
   contents: write

--- a/samples/pypi/manifest.json
+++ b/samples/pypi/manifest.json
@@ -739,6 +739,10 @@
     "licensemonitor": null,
     "lightgboost": null,
     "lightgmb": null,
+    "lightning": [
+        "2.6.2",
+        "2.6.3"
+    ],
     "lightseeq": null,
     "lightseqe": null,
     "lightsequ": null,


### PR DESCRIPTION
This PR fixes the incorrectly specified Octo configuration for the new `sync-manifest` workflow.

Other changes include:
    * Add entries for the recent `lightning` (PyPI) compromise to the manifest file