### PR TITLE
Remove incorrectly added manifest entry for npm|stylus

### DIFF
--- a/samples/npm/manifest.json
+++ b/samples/npm/manifest.json
@@ -37976,7 +37976,6 @@
     "stylelint-config-twbs-applestrap": null,
     "stylelint-recommended": null,
     "stylexjs-scripts": null,
-    "stylus": null,
     "stylus.js": null,
     "subchart": null,
     "subjective-sapphire-pigeon": null,


### PR DESCRIPTION
This PR removes `stylus` from the npm `manifest.json` file.  As detailed in #429 and #431 , this package was erroneously moved into security holding, which caused it to be marked malicious in our backend and thus erroneously added back into the dataset.

Closes #553 