### PR TITLE
[SECRES-5160] Pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/sync-malicious-packages.yaml
+++ b/.github/workflows/sync-malicious-packages.yaml
@@ -19,14 +19,14 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: eu-west-3
           role-to-assume: ${{ secrets.IAM_ROLE_ARN }}
@@ -52,7 +52,7 @@ jobs:
           policy: self.open_pr # trust policy in target repo
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           add-paths: |
             samples/

--- a/.github/workflows/sync-manifest.yaml
+++ b/.github/workflows/sync-manifest.yaml
@@ -19,14 +19,14 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: eu-west-3
           role-to-assume: ${{ secrets.IAM_ROLE_ARN }}
@@ -53,7 +53,7 @@ jobs:
           policy: self.open_pr # trust policy in target repo
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           add-paths: |
             samples/


### PR DESCRIPTION
This PR pins third-party GitHub Actions in the `sync-` workflows to specific commit hashes.