### PR TITLE
Remove empty dotenv-expand manifest entry

### DIFF
--- a/samples/npm/manifest.json
+++ b/samples/npm/manifest.json
@@ -15534,7 +15534,6 @@
     "dotenv-core": null,
     "dotenv-embed": null,
     "dotenv-embedded": null,
-    "dotenv-expand": [],
     "dotenv-expanded": null,
     "dotenv-express": null,
     "dotenv-extend": null,


### PR DESCRIPTION
This PR removes the manifest.json entry for npm package `dotenv-expand` from the dataset.