### PR TITLE
Revert Python version spec for typing-extensions dependency

### DIFF
--- a/scripts/sync-manifest/requirements.txt
+++ b/scripts/sync-manifest/requirements.txt
@@ -16,7 +16,7 @@ python-dateutil==2.9.0.post0 ; python_version >= "3.10" and python_version < "4"
 six==1.17.0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
-typing-extensions==4.16.0 ; python_version == "3.10" \
+typing-extensions==4.16.0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8 \
     --hash=sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5
 urllib3==2.7.0 ; python_version >= "3.10" and python_version < "4" \


### PR DESCRIPTION
This PR reverts a recent change to the Python version specification for the `typing-extensions` dependency in the `sync-manifest` script.